### PR TITLE
allow plain scalars under JSON

### DIFF
--- a/lib/Data/FlexSerializer.pm
+++ b/lib/Data/FlexSerializer.pm
@@ -17,7 +17,7 @@ use Constant::FromGlobal DEBUG => { int => 1, default => 0, env => 1 };
 
 use List::Util qw(min);
 use Storable qw();
-use JSON::XS qw();
+use JSON::XS 4 qw();
 use Sereal::Decoder qw();
 use Sereal::Encoder qw();
 use Compress::Zlib qw(Z_DEFAULT_COMPRESSION);

--- a/t/10basic.t
+++ b/t/10basic.t
@@ -203,10 +203,10 @@ foreach my $class ('Data::FlexSerializer', 'Data::FlexSerializer::EmptySubclass'
       $res = $serializer->serialize($data{garbage});
       1;
     };
-    if ($is_sereal) {
-      ok(!$eval_died, "Under Sereal we support serializing plain SvPV");
+    if ($is_sereal or $s_name =~ /^(json|flex|default)/) {
+      ok(!$eval_died, "Under Sereal and JSON we support serializing plain SvPV");
     } else {
-      ok($eval_died, "We should die under Storable and JSON when fed a plain SvPV");
+      ok($eval_died, "We should die under Storable when fed a plain SvPV");
     }
   }
 


### PR DESCRIPTION
Since JSON::XS 4 this is permitted, and this patch will fix the complete test failures since then.